### PR TITLE
Add chevron stripes pattern template

### DIFF
--- a/lib/templates/chevron-stripes.ts
+++ b/lib/templates/chevron-stripes.ts
@@ -1,0 +1,19 @@
+import type { P5Template } from "./types";
+import { drawRightwardChevronStripes } from "./utils";
+
+export const chevronStripes: P5Template = {
+  id: "chevron-stripes",
+  name: "Chevron Stripes",
+  description: "Rightward-facing chevrons with stacked color bands",
+  renderer: "p5",
+  draw: (g, colors) => {
+    if (colors.length < 3) return;
+
+    const stripes = colors.map((color, index) => ({
+      color,
+      size: index === 0 || index === colors.length - 1 ? 3.5 : 1,
+    }));
+
+    drawRightwardChevronStripes(g, stripes);
+  },
+};

--- a/lib/templates/index.ts
+++ b/lib/templates/index.ts
@@ -3,6 +3,7 @@ export { isP5Template, isPaperTemplate } from "./types";
 
 import { retroStripes } from "./retro-stripes";
 import { retroLines } from "./retro-lines";
+import { chevronStripes } from "./chevron-stripes";
 import { equalStripes } from "./equal-stripes";
 import { verticalStripes } from "./vertical-stripes";
 import { flowingWaves } from "./flowing-waves";
@@ -14,6 +15,7 @@ export const templates = [
   flowingWaves,      // p5.js version
   retroLines,
   retroStripes,
+  chevronStripes,
   verticalStripes,
   equalStripes,
   circleGrid,

--- a/lib/templates/utils.ts
+++ b/lib/templates/utils.ts
@@ -48,6 +48,39 @@ export function drawRotatedStripes(
   g.pop();
 }
 
+/**
+ * Draw rightward-facing chevron stripes (`>`).
+ *
+ * The canvas is split at the horizontal midline. The top half is filled with
+ * tl-br rotated stripes and the bottom half with bl-tr rotated stripes. With
+ * the natural canvas-diagonal angle used by `drawRotatedStripes`, each stripe's
+ * centerline meets at the same x on the midline, so the two halves form a
+ * crisp chevron point on the right edge.
+ */
+export function drawRightwardChevronStripes(
+  g: p5.Graphics,
+  stripes: { color: string; size: number }[]
+) {
+  const w = g.width;
+  const h = g.height;
+  const halfH = h / 2;
+  const ctx = g.drawingContext as CanvasRenderingContext2D;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, 0, w, halfH);
+  ctx.clip();
+  drawRotatedStripes(g, stripes, "tl-br");
+  ctx.restore();
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, halfH, w, halfH);
+  ctx.clip();
+  drawRotatedStripes(g, stripes, "bl-tr");
+  ctx.restore();
+}
+
 // Estimate perceived lightness from hex color (0-1)
 export function getLightness(hex: string): number {
   const r = parseInt(hex.slice(1, 3), 16);


### PR DESCRIPTION
## Summary
This PR adds a new "Chevron Stripes" pattern template that renders rightward-facing chevrons with stacked color bands.

## Key Changes
- **New utility function** `drawRightwardChevronStripes()` in `lib/templates/utils.ts`
  - Splits the canvas horizontally at the midline
  - Draws top-left to bottom-right stripes in the upper half
  - Draws bottom-left to top-right stripes in the lower half
  - Creates a crisp chevron point on the right edge where the stripe centerlines meet

- **New template** `lib/templates/chevron-stripes.ts`
  - Implements the `chevronStripes` P5Template
  - Requires minimum 3 colors
  - Applies variable stripe sizes: thicker outer bands (3.5) and thinner inner bands (1)

- **Template registration** in `lib/templates/index.ts`
  - Exports the new chevron stripes template
  - Adds it to the templates array

## Implementation Details
The chevron effect is achieved by leveraging the existing `drawRotatedStripes()` function with canvas clipping regions. By using complementary rotation directions (tl-br and bl-tr) on each half of the canvas, the stripe angles naturally converge to form a sharp chevron point on the right edge.

https://claude.ai/code/session_01MXQYdvgRtTxUy9cQxAktzn