### PR TITLE
Add wallpaper rotation feature with 90° increments

### DIFF
--- a/components/paper-canvas.tsx
+++ b/components/paper-canvas.tsx
@@ -2,9 +2,10 @@
 
 import { useRef, useEffect, useCallback, forwardRef, useImperativeHandle, useState } from "react";
 import type { PaperTemplate, WaveSettings } from "@/lib/templates";
+import { downloadCanvas } from "@/lib/download-canvas";
 
 export interface PaperCanvasHandle {
-  downloadImage: () => void;
+  downloadImage: (rotation: number) => void;
 }
 
 interface PaperCanvasProps {
@@ -49,14 +50,11 @@ export const PaperCanvas = forwardRef<PaperCanvasHandle, PaperCanvasProps>(
       draw();
     }, [draw]);
 
-    const downloadImage = useCallback(() => {
+    const downloadImage = useCallback((rotation: number) => {
       const canvas = canvasRef.current;
       if (!canvas) return;
 
-      const link = document.createElement("a");
-      link.download = `wallpaper-${template.id}-${Date.now()}.png`;
-      link.href = canvas.toDataURL("image/png");
-      link.click();
+      downloadCanvas(canvas, rotation, `wallpaper-${template.id}-${Date.now()}.png`);
     }, [template.id]);
 
     useImperativeHandle(ref, () => ({

--- a/components/wallpaper-canvas.tsx
+++ b/components/wallpaper-canvas.tsx
@@ -3,9 +3,10 @@
 import { useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
 import type p5Type from "p5";
 import type { P5Template } from "@/lib/templates";
+import { downloadCanvas } from "@/lib/download-canvas";
 
 export interface WallpaperCanvasHandle {
-  downloadImage: () => void;
+  downloadImage: (rotation: number) => void;
 }
 
 interface WallpaperCanvasProps {
@@ -91,13 +92,12 @@ export const WallpaperCanvas = forwardRef<WallpaperCanvasHandle, WallpaperCanvas
       draw();
     }, [draw]);
 
-    const downloadImage = useCallback(() => {
-      const p5 = p5Ref.current;
+    const downloadImage = useCallback((rotation: number) => {
       const graphics = graphicsRef.current;
-      if (!p5 || !graphics) return;
+      if (!graphics) return;
 
-      // Save the graphics buffer using p5's save method
-      p5.save(graphics, `wallpaper-${template.id}-${Date.now()}.png`);
+      const sourceCanvas = (graphics as unknown as { canvas: HTMLCanvasElement }).canvas;
+      downloadCanvas(sourceCanvas, rotation, `wallpaper-${template.id}-${Date.now()}.png`);
     }, [template.id]);
 
     useImperativeHandle(ref, () => ({

--- a/components/wallpaper-generator.tsx
+++ b/components/wallpaper-generator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Download, MessageCirclePlus } from "lucide-react";
+import { Download, MessageCirclePlus, RotateCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { PaletteSelector } from "@/components/palette-selector";
@@ -19,6 +19,7 @@ export function WallpaperGenerator() {
   const [selectedPaletteId, setSelectedPaletteId] = useState(palettes[0].id);
   const [selectedTemplateId, setSelectedTemplateId] = useState(templates[0].id);
   const [waveSettings, setWaveSettings] = useState<WaveSettingsType>(defaultWaveSettings);
+  const [rotation, setRotation] = useState(0);
   const p5CanvasRef = useRef<WallpaperCanvasHandle>(null);
   const paperCanvasRef = useRef<PaperCanvasHandle>(null);
 
@@ -31,13 +32,17 @@ export function WallpaperGenerator() {
 
   const handleDownload = () => {
     if (selectedTemplate && isP5Template(selectedTemplate)) {
-      p5CanvasRef.current?.downloadImage();
+      p5CanvasRef.current?.downloadImage(rotation);
     } else {
-      paperCanvasRef.current?.downloadImage();
+      paperCanvasRef.current?.downloadImage(rotation);
     }
   };
 
+  const handleRotate = () => setRotation((r) => (r + 90) % 360);
+
   if (!selectedTemplate) return null;
+
+  const isPortrait = rotation === 90 || rotation === 270;
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
@@ -49,21 +54,39 @@ export function WallpaperGenerator() {
         <p className="text-muted-foreground text-sm">Generate 4K wallpapers from color palettes</p>
       </div>
 
-      <div className="w-full max-w-4xl overflow-hidden rounded-xl border shadow-lg">
-        {isP5Template(selectedTemplate) ? (
-          <WallpaperCanvas
-            ref={p5CanvasRef}
-            colors={colors}
-            template={selectedTemplate as P5Template}
-          />
-        ) : isPaperTemplate(selectedTemplate) ? (
-          <PaperCanvas
-            ref={paperCanvasRef}
-            colors={colors}
-            template={selectedTemplate as PaperTemplate}
-            waveSettings={waveSettings}
-          />
-        ) : null}
+      <div
+        className={`relative overflow-hidden rounded-xl border shadow-lg ${
+          isPortrait ? "h-[80vh] max-h-[720px]" : "w-full max-w-4xl"
+        }`}
+        style={{
+          aspectRatio: isPortrait ? "9 / 16" : "16 / 9",
+        }}
+      >
+        <div
+          className="absolute left-1/2 top-1/2"
+          style={{
+            width: isPortrait ? `${(16 / 9) * 100}%` : "100%",
+            height: isPortrait ? `${(9 / 16) * 100}%` : "100%",
+            transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
+            transformOrigin: "center center",
+            transition: "transform 250ms ease-out",
+          }}
+        >
+          {isP5Template(selectedTemplate) ? (
+            <WallpaperCanvas
+              ref={p5CanvasRef}
+              colors={colors}
+              template={selectedTemplate as P5Template}
+            />
+          ) : isPaperTemplate(selectedTemplate) ? (
+            <PaperCanvas
+              ref={paperCanvasRef}
+              colors={colors}
+              template={selectedTemplate as PaperTemplate}
+              waveSettings={waveSettings}
+            />
+          ) : null}
+        </div>
       </div>
 
       <div className="flex flex-wrap items-center justify-center gap-4">
@@ -75,6 +98,10 @@ export function WallpaperGenerator() {
           value={selectedPaletteId}
           onValueChange={setSelectedPaletteId}
         />
+        <Button onClick={handleRotate} size="lg" variant="outline">
+          <RotateCw className="mr-2 h-4 w-4" />
+          Rotate 90&deg;
+        </Button>
         <Button onClick={handleDownload} size="lg">
           <Download className="mr-2 h-4 w-4" />
           Download 4K

--- a/lib/download-canvas.ts
+++ b/lib/download-canvas.ts
@@ -1,0 +1,44 @@
+/**
+ * Save an HTMLCanvasElement as a PNG download, optionally rotated by a
+ * multiple of 90 degrees. The output canvas swaps dimensions for 90/270
+ * so the rendered template fills the full image without padding.
+ */
+export function downloadCanvas(
+  source: HTMLCanvasElement,
+  rotation: number,
+  filename: string
+) {
+  const normalized = ((rotation % 360) + 360) % 360;
+  const sw = source.width;
+  const sh = source.height;
+
+  let outCanvas: HTMLCanvasElement = source;
+
+  if (normalized !== 0) {
+    const swap = normalized === 90 || normalized === 270;
+    const outW = swap ? sh : sw;
+    const outH = swap ? sw : sh;
+
+    const temp = document.createElement("canvas");
+    temp.width = outW;
+    temp.height = outH;
+    const ctx = temp.getContext("2d");
+    if (!ctx) return;
+
+    ctx.translate(outW / 2, outH / 2);
+    ctx.rotate((normalized * Math.PI) / 180);
+    ctx.drawImage(source, -sw / 2, -sh / 2);
+
+    outCanvas = temp;
+  }
+
+  outCanvas.toBlob((blob) => {
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, "image/png");
+}

--- a/lib/templates/overlapping-circles.ts
+++ b/lib/templates/overlapping-circles.ts
@@ -1,28 +1,10 @@
 import type { P5Template } from "./types";
 import { getLightness } from "./utils";
 
-interface CircleSpec {
-  cx: number; // fraction of width
-  cy: number; // fraction of height
-  r: number;  // fraction of height
-}
-
-// Composed Bauhaus-style layout: one dominant anchor, two mediums for
-// overlap, three smaller accents. Positions chosen so the larger circles
-// overlap meaningfully; the smaller ones punctuate the empty space.
-const CIRCLES: CircleSpec[] = [
-  { cx: 0.35, cy: 0.62, r: 0.55 },
-  { cx: 0.65, cy: 0.38, r: 0.32 },
-  { cx: 0.80, cy: 0.62, r: 0.26 },
-  { cx: 0.15, cy: 0.20, r: 0.13 },
-  { cx: 0.92, cy: 0.18, r: 0.10 },
-  { cx: 0.55, cy: 0.88, r: 0.11 },
-];
-
 export const overlappingCircles: P5Template = {
   id: "overlapping-circles",
   name: "Overlapping Circles",
-  description: "Bauhaus-style composition of stacked circles in varying sizes",
+  description: "Concentric circles fading from dark edges to a bright center",
   renderer: "p5",
   draw: (g, colors) => {
     if (colors.length < 2) return;
@@ -30,24 +12,30 @@ export const overlappingCircles: P5Template = {
     const w = g.width;
     const h = g.height;
 
-    const sortedByLightness = [...colors].sort(
-      (a, b) => getLightness(b) - getLightness(a)
+    // Darkest first (outer ring), lightest last (center).
+    const ordered = [...colors].sort(
+      (a, b) => getLightness(a) - getLightness(b)
     );
-    const bgColor = sortedByLightness[0];
-    const circleColors = sortedByLightness.slice(1).reverse();
-    if (circleColors.length === 0) return;
 
     g.smooth();
-    g.background(bgColor);
+    g.background(ordered[0]);
     g.noStroke();
 
-    const ordered = [...CIRCLES].sort((a, b) => b.r - a.r);
+    const cx = w / 2;
+    const cy = h / 2;
+    // Outer ring bleeds past the longer edge so the background color
+    // peeks through only at the corners, like the reference image.
+    const maxDiameter = Math.max(w, h) * 1.15;
+    const minDiameter = Math.min(w, h) * 0.18;
 
-    ordered.forEach((c, i) => {
-      const color = circleColors[i % circleColors.length];
-      g.fill(color);
-      const diameter = c.r * h * 2;
-      g.ellipse(c.cx * w, c.cy * h, diameter, diameter);
-    });
+    const ringCount = ordered.length;
+    for (let i = 0; i < ringCount; i++) {
+      const t = ringCount === 1 ? 0 : i / (ringCount - 1);
+      // Geometric falloff from maxDiameter to minDiameter.
+      const diameter =
+        maxDiameter * Math.pow(minDiameter / maxDiameter, t);
+      g.fill(ordered[i]);
+      g.ellipse(cx, cy, diameter, diameter);
+    }
   },
 };


### PR DESCRIPTION
## Summary
Added the ability to rotate wallpapers by 90-degree increments before download. The UI now includes a rotate button, and the canvas display adapts to portrait/landscape orientations with proper aspect ratio handling.

## Key Changes
- **Rotation State & UI**: Added rotation state management and a "Rotate 90°" button that cycles through 0°, 90°, 180°, and 270° rotations
- **Canvas Display**: Wrapped canvas in a rotatable container with dynamic aspect ratio (16:9 for landscape, 9:16 for portrait) and smooth CSS transitions
- **Download Handling**: Created new `downloadCanvas()` utility function that handles rotation during export by:
  - Swapping canvas dimensions for 90°/270° rotations to avoid padding
  - Using canvas 2D context to rotate and draw the source image
  - Exporting as PNG with proper filename
- **API Updates**: Updated `downloadImage()` method signatures in both `WallpaperCanvas` and `PaperCanvas` to accept rotation parameter
- **Template Improvement**: Refactored "Overlapping Circles" template from fixed Bauhaus-style layout to concentric circles with geometric falloff, creating a more elegant center-focused design

## Implementation Details
- Rotation is applied via CSS `transform: rotate()` on the canvas container for real-time preview
- Download applies rotation via canvas 2D context transformation to ensure the rotated image fills the output without padding
- Portrait mode (90°/270°) constrains height to 80vh with max-height of 720px to maintain usability
- Concentric circles template now sorts colors by lightness (darkest outer, lightest center) and uses geometric interpolation for smooth diameter transitions

https://claude.ai/code/session_01E3yDb1PyTUs1M6TKiGWytb